### PR TITLE
Use command to reload warning count

### DIFF
--- a/src/main/scala/sammy/WarningThresholdExceededException.scala
+++ b/src/main/scala/sammy/WarningThresholdExceededException.scala
@@ -1,8 +1,0 @@
-package sammy
-
-final case class WarningThresholdExceededException(numberOfWarnings: Int,
-                                                   threshold: Int)
-    extends Exception {
-  override def toString: String =
-    s"The number of warnings has increased from $threshold to $numberOfWarnings.  Please reduce warnings in your project."
-}

--- a/src/sbt-test/basic/newly-added-plugin/test
+++ b/src/sbt-test/basic/newly-added-plugin/test
@@ -1,4 +1,4 @@
-# The task should succeed as the threshold was met
+# The command should succeed as the threshold was met
 > policeWarnings
-# The threshold file should not have been written
+# The threshold file should have been written
 $ exists sammy.sbt

--- a/src/sbt-test/basic/threshold-exceeded-custom-configuration/test
+++ b/src/sbt-test/basic/threshold-exceeded-custom-configuration/test
@@ -1,2 +1,2 @@
-# The task should fail as the threshold was exceeded
--> checkWarningThreshold
+# The command should fail as the threshold was exceeded
+-> policeWarnings

--- a/src/sbt-test/basic/threshold-exceeded-multiple-projects/test
+++ b/src/sbt-test/basic/threshold-exceeded-multiple-projects/test
@@ -1,2 +1,2 @@
-# The task should fail as the threshold was exceeded
--> checkWarningThreshold
+# The command should fail as the threshold was exceeded
+-> policeWarnings

--- a/src/sbt-test/basic/threshold-exceeded/test
+++ b/src/sbt-test/basic/threshold-exceeded/test
@@ -1,2 +1,2 @@
-# The task should fail as the threshold was exceeded
--> checkWarningThreshold
+# The command should fail as the threshold was exceeded
+-> policeWarnings

--- a/src/sbt-test/basic/threshold-reduced-no-threshold-file/build.sbt
+++ b/src/sbt-test/basic/threshold-reduced-no-threshold-file/build.sbt
@@ -6,3 +6,11 @@ scalacOptions ++= Seq(
 
 sammyWarningThreshold  := 5
 sammyWarningThresholdFile := None
+
+val check = taskKey[Unit]("Check that the value of sammyWarningThreshold has been modified")
+
+check := {
+  val expected = 3
+  val actual = sammyWarningThreshold.value
+  assert(expected == actual, "Expected warning threshold of " + expected + ", got " + actual)
+}

--- a/src/sbt-test/basic/threshold-reduced-no-threshold-file/test
+++ b/src/sbt-test/basic/threshold-reduced-no-threshold-file/test
@@ -1,4 +1,6 @@
-# The task should succeed as the threshold was met
+# The command should succeed as the threshold was reduced
 > policeWarnings
 # The threshold file should not have been written
 -$ exists sammy.sbt
+# The threshold setting should have been updated
+> check

--- a/src/sbt-test/basic/threshold-reduced/build.sbt
+++ b/src/sbt-test/basic/threshold-reduced/build.sbt
@@ -3,3 +3,11 @@ scalaVersion := "2.12.8"
 scalacOptions ++= Seq(
   "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
 )
+
+val check = taskKey[Unit]("Check that the value of sammyWarningThreshold has been modified")
+
+check := {
+  val expected = 3
+  val actual = sammyWarningThreshold.value
+  assert(expected == actual, "Expected warning threshold of " + expected + ", got " + actual)
+}

--- a/src/sbt-test/basic/threshold-reduced/test
+++ b/src/sbt-test/basic/threshold-reduced/test
@@ -1,4 +1,6 @@
-# The task should fail as the threshold was exceeded
+# The command should succeed as the threshold was reduced
 > policeWarnings
 # The threshold should have been reduced
 $ must-mirror sammy.sbt resources/updatedSammy.sbt
+# The threshold setting should have been updated
+> check


### PR DESCRIPTION
This reloads the warning count as detailed in #1 .
The `policeWarnings` task has been changed into a command such that it can modify the sbt state.  There are also a few test fixes which were previously missed.